### PR TITLE
fix opam generation, disable transitive deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -5,6 +5,7 @@
 (version 1.0.0)
 
 (generate_opam_files true)
+(implicit_transitive_deps false)
 
 (source
  (github ip2location/ip2location-io-ocaml))

--- a/ip2locationio.opam.template
+++ b/ip2locationio.opam.template
@@ -1,0 +1,1 @@
+available: arch != "arm32" & arch != "x86_32"

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (public_name ip2locationio)
  (name ip2locationio)
- (libraries lwt cohttp cohttp-lwt-unix yojson))
+ (libraries lwt lwt.unix cohttp cohttp-lwt cohttp-lwt-unix uri yojson))

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name ip2locationiotest)
- (libraries ip2locationio))
+ (libraries ip2locationio yojson))


### PR DESCRIPTION
Hi,

I added a `ip2locationio.opam.template` file so that dune add what's inside it to `ip2locationio.opam` when generating it. Otherwise it's overwritten each time.

I also added some missing deps that were implicit and disabled implicit transitive deps so it does not happen again.

Cheers,