### PR TITLE
Fix OPAM metadata

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,14 @@
  (name ip2locationio)
  (synopsis "IP2Location.io OCaml module to get geolocation and WHOIS data")
  (description "IP2Location.io OCaml module allows user to query for an enriched data set based on IP address and provides WHOIS lookup api that helps users to obtain domain information. ")
- (depends (ocaml (>= "4.13")) dune lwt lwt.unix cohttp cohttp-lwt-unix uri (yojson (>= "1.6.0")))
+ (depends
+   (ocaml (>= "4.13"))
+   dune
+   lwt
+   cohttp
+   cohttp-lwt-unix
+   uri
+   (yojson (>= "1.6.0")))
  (tags (ip2locationio geolocation)))
 
 ; See the complete stanza docs at https://dune.readthedocs.io/en/stable/dune-files.html#dune-project

--- a/ip2locationio.opam
+++ b/ip2locationio.opam
@@ -17,7 +17,6 @@ depends: [
   "lwt"
   "cohttp"
   "cohttp-lwt-unix"
-  "tls-lwt" {with-test}
   "uri"
   "yojson" {>= "1.6.0"}
   "odoc" {with-doc}
@@ -32,6 +31,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
This PR removes lwt.unix (since that's not an OPAM package name but a findlib package name that is part of the lwt OPAM package) and also regenerates the opam file thus updates it to the current state of dune-project.

This change is necessary as Dune 3.13 introduces strict checking for OPAM package names and this package fails when applying these checks.